### PR TITLE
Add maven@3.8.1 ...

### DIFF
--- a/maven@3.8.1.rb
+++ b/maven@3.8.1.rb
@@ -1,0 +1,73 @@
+class Maven < Formula
+  desc "Java-based project management"
+  homepage "https://maven.apache.org/"
+  url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz"
+  sha256 "b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
+  license "Apache-2.0"
+
+  livecheck do
+    url "https://maven.apache.org/download.cgi"
+    regex(/href=.*?apache-maven[._-]v?(\d+(?:\.\d+)+)-bin\.t/i)
+  end
+
+  bottle do
+    sha256 cellar: :any,                 arm64_big_sur: "bb95e2849040358e1e30b918c5cfdcfb78535915d834f32f0f5fcb39231a87f6"
+    sha256 cellar: :any,                 big_sur:       "f894602e16a46f6d40a259c860d8f9d5103baac5681d1803349eaf5b6771f527"
+    sha256 cellar: :any,                 catalina:      "f894602e16a46f6d40a259c860d8f9d5103baac5681d1803349eaf5b6771f527"
+    sha256 cellar: :any,                 mojave:        "f894602e16a46f6d40a259c860d8f9d5103baac5681d1803349eaf5b6771f527"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fb05503b1a17a40a22060c04caab17ac630ba985194600065f746e9924a363bf"
+  end
+
+  depends_on "openjdk"
+
+  conflicts_with "mvnvm", because: "also installs a 'mvn' executable"
+
+  def install
+    # Remove windows files
+    rm_f Dir["bin/*.cmd"]
+
+    # Fix the permissions on the global settings file.
+    chmod 0644, "conf/settings.xml"
+
+    libexec.install Dir["*"]
+
+    # Leave conf file in libexec. The mvn symlink will be resolved and the conf
+    # file will be found relative to it
+    Pathname.glob("#{libexec}/bin/*") do |file|
+      next if file.directory?
+
+      basename = file.basename
+      next if basename.to_s == "m2.conf"
+
+      (bin/basename).write_env_script file, Language::Java.overridable_java_home_env
+    end
+  end
+
+  test do
+    (testpath/"pom.xml").write <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>org.homebrew</groupId>
+        <artifactId>maven-test</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <properties>
+          <maven.compiler.source>1.8</maven.compiler.source>
+          <maven.compiler.target>1.8</maven.compiler.target>
+          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        </properties>
+      </project>
+    EOS
+    (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<~EOS
+      package org.homebrew;
+      public class MavenTest {
+        public static void main(String[] args) {
+          System.out.println("Testing Maven with Homebrew!");
+        }
+      }
+    EOS
+    system "#{bin}/mvn", "compile", "-Duser.home=#{testpath}"
+  end
+end

--- a/maven@3.8.1.rb
+++ b/maven@3.8.1.rb
@@ -6,18 +6,7 @@ class MavenAT381 < Formula
   sha256 "b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
   license "Apache-2.0"
 
-  livecheck do
-    url "https://maven.apache.org/download.cgi"
-    regex(/href=.*?apache-maven[._-]v?(\d+(?:\.\d+)+)-bin\.t/i)
-  end
-
-  bottle do
-    sha256 cellar: :any,                 arm64_big_sur: "bb95e2849040358e1e30b918c5cfdcfb78535915d834f32f0f5fcb39231a87f6"
-    sha256 cellar: :any,                 big_sur:       "f894602e16a46f6d40a259c860d8f9d5103baac5681d1803349eaf5b6771f527"
-    sha256 cellar: :any,                 catalina:      "f894602e16a46f6d40a259c860d8f9d5103baac5681d1803349eaf5b6771f527"
-    sha256 cellar: :any,                 mojave:        "f894602e16a46f6d40a259c860d8f9d5103baac5681d1803349eaf5b6771f527"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fb05503b1a17a40a22060c04caab17ac630ba985194600065f746e9924a363bf"
-  end
+  bottle :unneeded
 
   depends_on "openjdk"
 

--- a/maven@3.8.1.rb
+++ b/maven@3.8.1.rb
@@ -1,4 +1,4 @@
-class Maven < Formula
+class MavenAT381 < Formula
   desc "Java-based project management"
   homepage "https://maven.apache.org/"
   url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz"
@@ -22,6 +22,7 @@ class Maven < Formula
   depends_on "openjdk"
 
   conflicts_with "mvnvm", because: "also installs a 'mvn' executable"
+  conflicts_with "maven", because: "also installs a 'mvn' executable"
 
   def install
     # Remove windows files


### PR DESCRIPTION
...from homebrew/homebrew-core@225b9036c0db7c4439de7ee540a07baa481dc2ae:Formula/maven.rb - for why this must be here when 3.8.2 is broken as per MINVOKER-283 please see PRs https://github.com/Homebrew/homebrew-core/pull/86188 and https://github.com/Homebrew/homebrew-core/pull/86192 - the Brew policy is very one-eyed and the Brew contributors are very police/military like in their obedience to it in the face of rock solid logic despite not having IQs to match the aforementioned groups. For the policy itself, see this link: https://docs.brew.sh/Versions

Please verify md5sum vs hash and history of maven.rb in the homebrew-core repo to confirm validity of this commit. 