### PR TITLE
fix: removed bottle :unneeded as it is deprecated

### DIFF
--- a/maven@3.8.1.rb
+++ b/maven@3.8.1.rb
@@ -6,8 +6,6 @@ class MavenAT381 < Formula
   sha256 "b98a1905eb554d07427b2e5509ff09bd53e2f1dd7a0afa38384968b113abef02"
   license "Apache-2.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   conflicts_with "mvnvm", because: "also installs a 'mvn' executable"


### PR DESCRIPTION
### Description of error:

```
Error: Invalid formula: /opt/homebrew/Library/Taps/branchout/homebrew-branchout/maven@3.8.1.rb
maven@3.8.1: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the branchout/branchout tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/branchout/homebrew-branchout/maven@3.8.1.rb:9

Error: Cannot tap branchout/branchout: invalid syntax in tap!
```

### How to reproduce the error:

Run command on MacOs(12.3.1): `brew tap Branchout/homebrew-branchout`

### Proposed solution:

Remove bottle :unneeded?